### PR TITLE
fix: Revert "chore(deps):update dependency macaroonbakery to v1.3.3"

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,7 @@ flake8-docstrings
 flake8-builtins
 isort
 juju
-macaroonbakery==1.3.3  # https://protobuf.dev/news/2022-05-06/#python-updates
+macaroonbakery==1.3.2  # https://protobuf.dev/news/2022-05-06/#python-updates
 mypy
 pep8-naming
 pyproject-flake8


### PR DESCRIPTION
# Description

Revert back to macaroonbakery version update to v1.3.3 which is done by renovate automatically.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library