### PR TITLE
chore: use the collect status event to set blocked status on relation broken

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -86,7 +86,6 @@ class GNBSIMOperatorCharm(CharmBase):
         self.framework.observe(self.on.gnbsim_pebble_ready, self._configure)
         self.framework.observe(self.on.start_simulation_action, self._on_start_simulation_action)
         self.framework.observe(self.on.fiveg_n2_relation_joined, self._configure)
-        self.framework.observe(self.on.fiveg_n2_relation_broken, self._on_n2_relation_broken)
         self.framework.observe(self._n2_requirer.on.n2_information_available, self._configure)
         self.framework.observe(
             self._gnb_identity_provider.on.fiveg_gnb_identity_request,
@@ -234,9 +233,6 @@ class GNBSIMOperatorCharm(CharmBase):
                 spec={"config": json.dumps(gnb_nad_config)},
             ),
         ]
-
-    def _on_n2_relation_broken(self, event: EventBase):
-        self.unit.status = BlockedStatus("Waiting for N2 relation to be created")
 
     def _update_fiveg_gnb_identity_relation_data(self) -> None:
         """Publishes GNB name and TAC in the `fiveg_gnb_identity` relation data bag."""


### PR DESCRIPTION
# Description

The `collect_unit_status` event is triggered after every hook. It will be triggered after N2 relation broken event. So we can remove the handler.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library