### PR TITLE
chore: Move to codespell and ruff 

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,7 @@ options:
     description: gNodeB IP Address
   gnb-interface:
     type: string
-    description: Host interface to use for the RAN Network. If unspecificed, a bridge will be used.
+    description: Host interface to use for the RAN Network. If unspecified, a bridge will be used.
   icmp-packet-destination:
     type: string
     default: "192.168.250.1"

--- a/lib/charms/sdcore_gnbsim_k8s/v0/fiveg_gnb_identity.py
+++ b/lib/charms/sdcore_gnbsim_k8s/v0/fiveg_gnb_identity.py
@@ -97,7 +97,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 
@@ -141,7 +141,7 @@ class ProviderSchema(DataBagSchema):
 
 
 def data_matches_provider_schema(data: dict) -> bool:
-    """Returns whether data matches provider schema.
+    """Return whether data matches provider schema.
 
     Args:
         data (dict): Data to be validated.
@@ -161,7 +161,7 @@ class FivegGnbIdentityRequestEvent(EventBase):
     """Dataclass for the `fiveg_gnb_identity` request event."""
 
     def __init__(self, handle: Handle, relation_id: int):
-        """Sets relation id.
+        """Set relation id.
 
         Args:
             handle (Handle): Juju framework handle.
@@ -171,7 +171,7 @@ class FivegGnbIdentityRequestEvent(EventBase):
         self.relation_id = relation_id
 
     def snapshot(self) -> dict:
-        """Returns event data.
+        """Return event data.
 
         Returns:
             (dict): contains the relation ID.
@@ -181,7 +181,7 @@ class FivegGnbIdentityRequestEvent(EventBase):
         }
 
     def restore(self, snapshot: dict) -> None:
-        """Restores event data.
+        """Restore event data.
 
         Args:
             snapshot (dict): contains the relation ID.
@@ -201,7 +201,7 @@ class GnbIdentityProvides(Object):
     on = GnbIdentityProviderCharmEvents()
 
     def __init__(self, charm: CharmBase, relation_name: str):
-        """Observes relation joined event.
+        """Observe relation joined event.
 
         Args:
             charm: Juju charm
@@ -215,7 +215,7 @@ class GnbIdentityProvides(Object):
     def publish_gnb_identity_information(
             self, relation_id: int, gnb_name: str, tac: int
     ) -> None:
-        """Sets gNodeB's name and TAC in the relation data.
+        """Set gNodeB's name and TAC in the relation data.
 
         Args:
             relation_id (str): Relation ID
@@ -247,20 +247,21 @@ class GnbIdentityAvailableEvent(EventBase):
     """Dataclass for the `fiveg_gnb_identity` available event."""
 
     def __init__(self, handle: Handle, gnb_name: str, tac: str):
-        """Sets gNodeB's name and TAC."""
+        """Set gNodeB's name and TAC."""
         super().__init__(handle)
         self.gnb_name = gnb_name
         self.tac = tac
 
     def snapshot(self) -> dict:
-        """Returns event data."""
+        """Return event data."""
         return {
             "gnb_name": self.gnb_name,
             "tac": self.tac,
         }
 
     def restore(self, snapshot: dict) -> None:
-        """Restores event data.
+        """Restore event data.
+
         Args:
             snapshot (dict): contains information to be restored.
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,24 +9,29 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 
-# Formatting tools configuration
-[tool.black]
+[tool.ruff]
 line-length = 99
-target-version = ["py310"]
 
-[tool.isort]
-line_length = 99
-profile = "black"
+[tool.ruff.lint]
+select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-ignore = [
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+ignore = ["E501", "D107"]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
-# Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
+[tool.ruff.lint.mccabe]
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore D107 Missing docstring in __init__
-ignore = ["D107"]
-# D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"
+
+[tool.codespell]
+skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"

--- a/src/charm.py
+++ b/src/charm.py
@@ -171,7 +171,7 @@ class GNBSIMOperatorCharm(CharmBase):
         self._create_upf_route()
 
     def _on_start_simulation_action(self, event: ActionEvent) -> None:
-        """Runs gnbsim simulation leveraging configuration file."""
+        """Run gnbsim simulation leveraging configuration file."""
         if not self._container.can_connect():
             event.fail(message="Container is not ready")
             return
@@ -198,7 +198,7 @@ class GNBSIMOperatorCharm(CharmBase):
             event.fail(message=f"Failed to execute simulation: {e.err}")
 
     def _generate_network_annotations(self) -> List[NetworkAnnotation]:
-        """Generates a list of NetworkAnnotations to be used by gnbsim's StatefulSet.
+        """Generate a list of NetworkAnnotations to be used by gnbsim's StatefulSet.
 
         Returns:
             List[NetworkAnnotation]: List of NetworkAnnotations
@@ -210,7 +210,7 @@ class GNBSIMOperatorCharm(CharmBase):
         ]
 
     def _network_attachment_definitions_from_config(self) -> list[NetworkAttachmentDefinition]:
-        """Returns list of Multus NetworkAttachmentDefinitions to be created based on config."""
+        """Return list of Multus NetworkAttachmentDefinitions to be created based on config."""
         gnb_nad_config = {
             "cniVersion": "0.3.1",
             "ipam": {
@@ -235,7 +235,7 @@ class GNBSIMOperatorCharm(CharmBase):
         ]
 
     def _update_fiveg_gnb_identity_relation_data(self) -> None:
-        """Publishes GNB name and TAC in the `fiveg_gnb_identity` relation data bag."""
+        """Publish GNB name and TAC in the `fiveg_gnb_identity` relation data bag."""
         if not self.unit.is_leader():
             return
         fiveg_gnb_identity_relations = self.model.relations.get(GNB_IDENTITY_RELATION_NAME)
@@ -322,7 +322,7 @@ class GNBSIMOperatorCharm(CharmBase):
         usim_opc: str,
         usim_sequence_number: str,
     ) -> str:
-        """Renders config file based on parameters.
+        """Render config file based on parameters.
 
         Args:
             amf_hostname: AMF hostname
@@ -361,7 +361,7 @@ class GNBSIMOperatorCharm(CharmBase):
         )
 
     def _get_invalid_configs(self) -> list[str]:  # noqa: C901
-        """Gets list of invalid Juju configurations."""
+        """Get list of invalid Juju configurations."""
         invalid_configs = []
         if not self._get_gnb_ip_address_from_config():
             invalid_configs.append("gnb-ip-address")
@@ -392,7 +392,7 @@ class GNBSIMOperatorCharm(CharmBase):
         return invalid_configs
 
     def _create_upf_route(self) -> None:
-        """Creates route to reach the UPF."""
+        """Create route to reach the UPF."""
         self._exec_command_in_workload(
             command=f"ip route replace {self._get_upf_subnet_from_config()} via {self._get_upf_gateway_from_config()}"  # noqa: E501
         )
@@ -402,7 +402,7 @@ class GNBSIMOperatorCharm(CharmBase):
         self,
         command: str,
     ) -> Tuple[Optional[str], Optional[str]]:
-        """Executes command in workload container.
+        """Execute command in workload container.
 
         Args:
             command: Command to execute
@@ -414,7 +414,7 @@ class GNBSIMOperatorCharm(CharmBase):
         return process.wait_output()
 
     def _relation_created(self, relation_name: str) -> bool:
-        """Returns whether a given Juju relation was crated.
+        """Return whether a given Juju relation was created.
 
         Args:
             relation_name (str): Relation name

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,14 +1,10 @@
-black
+codespell
 coverage[toml]
-flake8-docstrings
-flake8-builtins
-isort
 juju
 mypy
-pep8-naming
-pyproject-flake8
 pytest
 pytest-operator
+ruff
 types-PyYAML
 types-setuptools
 types-toml

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,8 +8,6 @@ asttokens==2.4.1
     # via stack-data
 bcrypt==4.1.2
     # via paramiko
-black==24.3.0
-    # via -r test-requirements.in
 cachetools==5.3.3
     # via google-auth
 certifi==2024.2.2
@@ -18,32 +16,25 @@ certifi==2024.2.2
     #   requests
 cffi==1.16.0
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
     # via requests
-click==8.1.7
-    # via black
+codespell==2.2.6
+    # via -r test-requirements.in
 coverage[toml]==7.4.4
     # via -r test-requirements.in
 cryptography==42.0.5
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
 executing==2.0.1
     # via stack-data
-flake8==6.1.0
-    # via
-    #   flake8-builtins
-    #   flake8-docstrings
-    #   pep8-naming
-    #   pyproject-flake8
-flake8-builtins==2.5.0
-    # via -r test-requirements.in
-flake8-docstrings==1.7.0
-    # via -r test-requirements.in
 google-auth==2.28.1
     # via kubernetes
 hvac==2.1.0
@@ -51,17 +42,19 @@ hvac==2.1.0
 idna==3.6
     # via requests
 iniconfig==2.0.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 ipdb==0.13.13
     # via pytest-operator
 ipython==8.22.2
     # via ipdb
-isort==5.13.2
-    # via -r test-requirements.in
 jedi==0.19.1
     # via ipython
 jinja2==3.1.3
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 juju==3.4.0.0
     # via
     #   -r test-requirements.in
@@ -71,16 +64,15 @@ kubernetes==29.0.0
 macaroonbakery==1.3.4
     # via juju
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements.txt
+    #   jinja2
 matplotlib-inline==0.1.6
     # via ipython
-mccabe==0.7.0
-    # via flake8
 mypy==1.9.0
     # via -r test-requirements.in
 mypy-extensions==1.0.0
     # via
-    #   black
     #   mypy
     #   typing-inspect
 oauthlib==3.2.2
@@ -89,23 +81,19 @@ oauthlib==3.2.2
     #   requests-oauthlib
 packaging==23.2
     # via
-    #   black
+    #   -c requirements.txt
     #   juju
     #   pytest
 paramiko==3.4.0
     # via juju
 parso==0.8.3
     # via jedi
-pathspec==0.12.1
-    # via black
-pep8-naming==0.13.3
-    # via -r test-requirements.in
 pexpect==4.9.0
     # via ipython
-platformdirs==4.2.0
-    # via black
 pluggy==1.4.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 prompt-toolkit==3.0.43
     # via ipython
 protobuf==4.25.3
@@ -121,14 +109,10 @@ pyasn1==0.5.1
     #   rsa
 pyasn1-modules==0.3.0
     # via google-auth
-pycodestyle==2.11.1
-    # via flake8
 pycparser==2.21
-    # via cffi
-pydocstyle==6.3.0
-    # via flake8-docstrings
-pyflakes==3.1.0
-    # via flake8
+    # via
+    #   -c requirements.txt
+    #   cffi
 pygments==2.17.2
     # via ipython
 pymacaroons==0.13.0
@@ -138,14 +122,13 @@ pynacl==1.5.0
     #   macaroonbakery
     #   paramiko
     #   pymacaroons
-pyproject-flake8==6.1.0
-    # via -r test-requirements.in
 pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
 pytest==8.1.1
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   pytest-asyncio
     #   pytest-operator
@@ -159,6 +142,7 @@ pytz==2024.1
     # via pyrfc3339
 pyyaml==6.0.1
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
     #   pytest-operator
@@ -172,6 +156,8 @@ requests-oauthlib==1.3.1
     # via kubernetes
 rsa==4.9
     # via google-auth
+ruff==0.3.5
+    # via -r test-requirements.in
 six==1.16.0
     # via
     #   asttokens
@@ -179,8 +165,6 @@ six==1.16.0
     #   macaroonbakery
     #   pymacaroons
     #   python-dateutil
-snowballstemmer==2.2.0
-    # via pydocstyle
 stack-data==0.6.3
     # via ipython
 toposort==1.10
@@ -197,6 +181,7 @@ types-toml==0.10.8.20240310
     # via -r test-requirements.in
 typing-extensions==4.10.0
     # via
+    #   -c requirements.txt
     #   mypy
     #   typing-inspect
 typing-inspect==0.9.0
@@ -208,6 +193,8 @@ urllib3==2.2.1
 wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.7.0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 websockets==12.0
     # via juju

--- a/tests/unit/lib/charms/sdcore_gnbsim/v0/test_charms/test_provider_charm/src/charm.py
+++ b/tests/unit/lib/charms/sdcore_gnbsim/v0/test_charms/test_provider_charm/src/charm.py
@@ -15,7 +15,7 @@ class WhateverCharm(CharmBase):
     TEST_TAC = ""
 
     def __init__(self, *args):
-        """Creates a new instance of this object for each event."""
+        """Create a new instance of this object for each event."""
         super().__init__(*args)
         self.gnb_identity_provider = GnbIdentityProvides(self, "fiveg_gnb_identity")
 

--- a/tests/unit/lib/charms/sdcore_gnbsim/v0/test_charms/test_requirer_charm/src/charm.py
+++ b/tests/unit/lib/charms/sdcore_gnbsim/v0/test_charms/test_requirer_charm/src/charm.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 class WhateverCharm(CharmBase):
     def __init__(self, *args):
-        """Creates a new instance of this object for each event."""
+        """Create a new instance of this object for each event."""
         super().__init__(*args)
         self.fiveg_gnb_identity = GnbIdentityRequires(self, "fiveg_gnb_identity")
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,18 +5,17 @@ import json
 import unittest
 from unittest.mock import Mock, call, patch
 
+from charm import GNBSIMOperatorCharm
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.pebble import ChangeError
-
-from charm import GNBSIMOperatorCharm
 
 MULTUS_LIB_PATH = "charms.kubernetes_charm_libraries.v0.multus"
 GNB_IDENTITY_LIB_PATH = "charms.sdcore_gnbsim_k8s.v0.fiveg_gnb_identity"
 
 
 def read_file(path: str) -> str:
-    """Reads a file and returns as a string.
+    """Read a file and returns as a string.
 
     Args:
         path (str): path to the file.
@@ -52,7 +51,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
 
     def _create_n2_relation(self) -> int:
-        """Creates a relation between gnbsim and amf.
+        """Create a relation between gnbsim and amf.
 
         Returns:
             int: Id of the created relation
@@ -62,7 +61,7 @@ class TestCharm(unittest.TestCase):
         return amf_relation_id
 
     def _n2_data_available(self) -> int:
-        """Creates the N2 relation, sets the relation data in the n2 relation and returns its ID.
+        """Create the N2 relation, sets the relation data in the n2 relation and returns its ID.
 
         Returns:
             int: ID of the created relation

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,8 @@ envlist = lint, static, unit
 src_path = {toxinidir}/src/
 unit_test_path = {toxinidir}/tests/unit/
 integration_test_path = {toxinidir}/tests/integration/
-all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
+lib_path = {toxinidir}/lib/charms/sdcore_gnbsim_k8s/v0
+all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path} {[vars]lib_path}
 
 [testenv]
 setenv =
@@ -28,15 +29,13 @@ passenv =
 [testenv:fmt]
 description = Apply coding style standards to code
 commands =
-    isort {[vars]all_path}
-    black {[vars]all_path}
+    ruff check --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 commands =
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
-    black --check --diff {[vars]all_path}
+    codespell {tox_root}
+    ruff check {[vars]all_path}
 
 [testenv:static]
 description = Run static analysis checks


### PR DESCRIPTION
# Description

Move to ruff and codespell for linting. `pyproject-flake8` is currently broken on Python 3.12, making development on Noble break.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library