### PR TITLE
fix: tell type checkers that the config options are strings

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -6,7 +6,7 @@
 
 import json
 import logging
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, cast
 
 from charms.kubernetes_charm_libraries.v0.multus import (  # type: ignore[import]
     KubernetesMultusCharmLib,
@@ -255,46 +255,46 @@ class GNBSIMOperatorCharm(CharmBase):
             )
 
     def _get_gnb_ip_address_from_config(self) -> Optional[str]:
-        return self.model.config.get("gnb-ip-address")
+        return cast(Optional[str], self.model.config.get("gnb-ip-address"))
 
     def _get_gnb_interface_from_config(self) -> Optional[str]:
-        return self.model.config.get("gnb-interface")
+        return cast(Optional[str], self.model.config.get("gnb-interface"))
 
     def _get_icmp_packet_destination_from_config(self) -> Optional[str]:
-        return self.model.config.get("icmp-packet-destination")
+        return cast(Optional[str], self.model.config.get("icmp-packet-destination"))
 
     def _get_imsi_from_config(self) -> Optional[str]:
-        return self.model.config.get("imsi")
+        return cast(Optional[str], self.model.config.get("imsi"))
 
     def _get_mcc_from_config(self) -> Optional[str]:
-        return self.model.config.get("mcc")
+        return cast(Optional[str], self.model.config.get("mcc"))
 
     def _get_mnc_from_config(self) -> Optional[str]:
-        return self.model.config.get("mnc")
+        return cast(Optional[str], self.model.config.get("mnc"))
 
     def _get_sd_from_config(self) -> Optional[str]:
-        return self.model.config.get("sd")
+        return cast(Optional[str], self.model.config.get("sd"))
 
     def _get_sst_from_config(self) -> Optional[int]:
         return int(self.model.config.get("sst"))  # type: ignore[arg-type]
 
     def _get_tac_from_config(self) -> Optional[str]:
-        return self.model.config.get("tac")
+        return cast(Optional[str], self.model.config.get("tac"))
 
     def _get_upf_gateway_from_config(self) -> Optional[str]:
-        return self.model.config.get("upf-gateway")
+        return cast(Optional[str], self.model.config.get("upf-gateway"))
 
     def _get_upf_subnet_from_config(self) -> Optional[str]:
-        return self.model.config.get("upf-subnet")
+        return cast(Optional[str], self.model.config.get("upf-subnet"))
 
     def _get_usim_key_from_config(self) -> Optional[str]:
-        return self.model.config.get("usim-key")
+        return cast(Optional[str], self.model.config.get("usim-key"))
 
     def _get_usim_opc_from_config(self) -> Optional[str]:
-        return self.model.config.get("usim-opc")
+        return cast(Optional[str], self.model.config.get("usim-opc"))
 
     def _get_usim_sequence_number_from_config(self) -> Optional[str]:
-        return self.model.config.get("usim-sequence-number")
+        return cast(Optional[str], self.model.config.get("usim-sequence-number"))
 
     def _write_config_file(self, content: str) -> None:
         self._container.push(source=content, path=f"{BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}")


### PR DESCRIPTION
# Description

ops<=2.12 wrongly has `self.config[x]` typed as `str`, when actually it could be an int, float, bool, or str, depending on the config type. We're fixing this in [ops:#1183](https://github.com/canonical/operator/pull/1183), but that will break static checking that currently assumes that the config is a str (because ops doesn't validate the schema, so all options will be bool|int|float|str).

This PR adds a `typing.cast` call where the config values are loaded and used where the type should be str.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation N/A
- [ ] I have added tests that validate the behaviour of the software N/A
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules N/A
- [ ] I have bumped the version of the library N/A