### PR TITLE
chore: enable codespell in charm's lib and enable line length check

### DIFF
--- a/lib/charms/sdcore_gnbsim_k8s/v0/fiveg_gnb_identity.py
+++ b/lib/charms/sdcore_gnbsim_k8s/v0/fiveg_gnb_identity.py
@@ -6,7 +6,8 @@
 This library contains the Requires and Provides classes for handling the `fiveg_gnb_identity`
 interface.
 
-The purpose of this library is to provide a way for gNodeB's to share their identity with the charms which require this information.
+The purpose of this library is to provide a way for gNodeB's to share their identity with the
+charms which require this information.
 
 To get started using the library, you need to fetch the library using `charmcraft`.
 
@@ -31,9 +32,15 @@ Typical usage of this class would look something like:
 
         def __init__(self, *args):
             ...
-            self.gnb_identity_provider = GnbIdentityProvides(charm=self, relation_name="fiveg_gnb_identity")
+            self.gnb_identity_provider = GnbIdentityProvides(
+                charm=self,
+                relation_name="fiveg_gnb_identity"
+                )
             ...
-            self.framework.observe(self.gnb_identity_provider.on.fiveg_gnb_identity_request, self._on_fiveg_gnb_identity_request)
+            self.framework.observe(
+                self.gnb_identity_provider.on.fiveg_gnb_identity_request,
+                self._on_fiveg_gnb_identity_request
+            )
 
         def _on_fiveg_gnb_identity_request(self, event):
             ...
@@ -63,7 +70,10 @@ Typical usage of this class would look something like:
 
         def __init__(self, *args):
             ...
-            self.fiveg_gnb_identity = GnbIdentityRequires(charm=self, relation_name="fiveg_gnb_identity")
+            self.fiveg_gnb_identity = GnbIdentityRequires(
+                charm=self,
+                relation_name="fiveg_gnb_identity"
+            )
             ...
             self.framework.observe(self.fiveg_gnb_identity.on.fiveg_gnb_identity_available,
                 self._on_fiveg_gnb_identity_available)
@@ -294,7 +304,7 @@ class GnbIdentityRequires(Object):
         self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
-        """Triggered everytime there's a change in relation data.
+        """Triggered every time there's a change in relation data.
 
         Args:
             event (RelationChangedEvent): Juju event

--- a/lib/charms/sdcore_gnbsim_k8s/v0/fiveg_gnb_identity.py
+++ b/lib/charms/sdcore_gnbsim_k8s/v0/fiveg_gnb_identity.py
@@ -107,7 +107,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ extend-ignore = [
     "D204",
     "D213",
     "D215",
+    "D107",
     "D400",
     "D404",
     "D406",
@@ -27,7 +28,6 @@ extend-ignore = [
     "D409",
     "D413",
 ]
-ignore = ["E501", "D107"]
 per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
 [tool.ruff.lint.mccabe]

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ commands =
 [testenv:lint]
 description = Check code against coding style standards
 commands =
+    codespell {[vars]lib_path}
     codespell {tox_root}
     ruff check {[vars]all_path}
 


### PR DESCRIPTION
# Description

Execute codespell over the charm's library on the tox.ini file.
Enable line length check (E501)

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library