### PR TITLE
chore: use release version of sdcore github workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,4 +8,4 @@ on:
 jobs:
   codeql:
     name: CodeQL Analysis
-    uses: canonical/sdcore-github-workflows/.github/workflows/codeql-analysis.yml@main
+    uses: canonical/sdcore-github-workflows/.github/workflows/codeql-analysis.yml@v0.0.1

--- a/.github/workflows/dependabot_pr.yaml
+++ b/.github/workflows/dependabot_pr.yaml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   auto-merge:
-    uses: canonical/sdcore-github-workflows/.github/workflows/dependabot_pr.yaml@main
+    uses: canonical/sdcore-github-workflows/.github/workflows/dependabot_pr.yaml@v0.0.1

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -7,6 +7,6 @@ on:
 jobs:
   update:
     name: Update Issue
-    uses: canonical/sdcore-github-workflows/.github/workflows/issues.yaml@main
+    uses: canonical/sdcore-github-workflows/.github/workflows/issues.yaml@v0.0.1
     secrets:
       JIRA_URL: ${{ secrets.JIRA_URL }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,24 +10,24 @@ on:
 
 jobs:
   check-libraries:
-    uses: canonical/sdcore-github-workflows/.github/workflows/check-libraries.yaml@main
+    uses: canonical/sdcore-github-workflows/.github/workflows/check-libraries.yaml@v0.0.1
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
 
   lint-report:
-    uses: canonical/sdcore-github-workflows/.github/workflows/lint-report.yaml@main
+    uses: canonical/sdcore-github-workflows/.github/workflows/lint-report.yaml@v0.0.1
 
   terraform-check:
-    uses: canonical/sdcore-github-workflows/.github/workflows/terraform.yaml@main
+    uses: canonical/sdcore-github-workflows/.github/workflows/terraform.yaml@v0.0.1
 
   static-analysis:
-    uses: canonical/sdcore-github-workflows/.github/workflows/static-analysis.yaml@main
+    uses: canonical/sdcore-github-workflows/.github/workflows/static-analysis.yaml@v0.0.1
 
   unit-tests-with-coverage:
-    uses: canonical/sdcore-github-workflows/.github/workflows/unit-test.yaml@main
+    uses: canonical/sdcore-github-workflows/.github/workflows/unit-test.yaml@v0.0.1
 
   integration-test:
-    uses: canonical/sdcore-github-workflows/.github/workflows/integration-test-with-multus.yaml@main
+    uses: canonical/sdcore-github-workflows/.github/workflows/integration-test-with-multus.yaml@v0.0.1
     with:
       charm-file-name: "sdcore-gnbsim-k8s_ubuntu-22.04-amd64.charm"
 
@@ -39,7 +39,7 @@ jobs:
       - unit-tests-with-coverage
       - integration-test
     if: ${{ github.ref_name == 'main' }}
-    uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@main
+    uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@v0.0.1
     with:
       charm-file-name: "sdcore-gnbsim-k8s_ubuntu-22.04-amd64.charm"
       track-name: 1.4
@@ -54,7 +54,7 @@ jobs:
       - unit-tests-with-coverage
       - integration-test
     if: ${{ (github.ref_name != 'main') && (github.event_name == 'push') }}
-    uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@main
+    uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@v0.0.1
     with:
       branch-name: ${{ github.ref_name }}
       charm-file-name: "sdcore-gnbsim-k8s_ubuntu-22.04-amd64.charm"
@@ -81,7 +81,7 @@ jobs:
       - publish-charm
       - fiveg-gnb-identity-lib-needs-publishing
     if: ${{ github.ref_name == 'main' }}
-    uses: canonical/sdcore-github-workflows/.github/workflows/publish-lib.yaml@main
+    uses: canonical/sdcore-github-workflows/.github/workflows/publish-lib.yaml@v0.0.1
     with:
       lib-name: "charms.sdcore_gnbsim_k8s.v0.fiveg_gnb_identity"
     secrets:

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -21,7 +21,7 @@ on:
 jobs:
   promote:
     name: Promote Charm
-    uses: canonical/sdcore-github-workflows/.github/workflows/promote.yaml@main
+    uses: canonical/sdcore-github-workflows/.github/workflows/promote.yaml@v0.0.1
     with:
       promotion: ${{ github.event.inputs.promotion }}
       track-name: ${{ github.event.inputs.track-name }}


### PR DESCRIPTION
# Description

Use the release version of sdcore-github workflows instead of using the main branch.

## Rationale

This will allow to make breaking changes in the workflows without breaking its dependents. More specifically, we are working on building the charm in its independent workflow step instead of having it built in the integration tests. Making such change in the workflows would break every NF CI until they adapt to the new workflow approach. Here we want to avoid this and have the workflow keep on working until we intentionally adopt the new approach.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library