### PR TITLE
fix: Charm doesn't handle missing Multus correctly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ sudo microk8s enable multus
 
 Install Juju and bootstrap a controller on the MicroK8S instance:
 ```shell
-sudo snap install juju --channel=3.1/stable
+sudo snap install juju --channel=3.4/stable
 juju bootstrap microk8s
 ```
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -127,6 +127,10 @@ class GNBSIMOperatorCharm(CharmBase):
         """
         if self._get_invalid_configs():
             return
+        if not self._kubernetes_multus.multus_is_available():
+            return
+        if not self._kubernetes_multus.is_ready():
+            return
         self._kubernetes_multus.configure()
         if not self._relation_created(N2_RELATION_NAME):
             return
@@ -134,13 +138,8 @@ class GNBSIMOperatorCharm(CharmBase):
             return
         if not self._container.exists(path=BASE_CONFIG_PATH):
             return
-        if not self._kubernetes_multus.multus_is_available():
-            return
-        if not self._kubernetes_multus.is_ready():
-            return
         if not self._n2_requirer.amf_hostname or not self._n2_requirer.amf_port:
             return
-
         if not self._n2_requirer.amf_hostname:
             return
         if not (gnb_ip_address := self._get_gnb_ip_address_from_config()):

--- a/src/charm.py
+++ b/src/charm.py
@@ -129,14 +129,14 @@ class GNBSIMOperatorCharm(CharmBase):
             return
         if not self._kubernetes_multus.multus_is_available():
             return
-        if not self._kubernetes_multus.is_ready():
-            return
         self._kubernetes_multus.configure()
         if not self._relation_created(N2_RELATION_NAME):
             return
         if not self._container.can_connect():
             return
         if not self._container.exists(path=BASE_CONFIG_PATH):
+            return
+        if not self._kubernetes_multus.is_ready():
             return
         if not self._n2_requirer.amf_hostname or not self._n2_requirer.amf_port:
             return


### PR DESCRIPTION
# Description

We get an hook failed: "storage-attached" failure when multus is not enabled.
![image](https://github.com/user-attachments/assets/5cbcf13a-98c4-42da-ac21-41e779d2d089)

This PR fixes it. Now, when Multus is not available in the K8s cluster, the charm remains in BlockedStatus with a proper error message.

![image](https://github.com/user-attachments/assets/d490335b-aac7-4fe1-ac3d-7adc43f02714)


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library