### PR TITLE
feat: add additional 5G simulation profiles

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -118,6 +118,10 @@ config:
       type: string
       default: "192.168.251.1"
       description: Gateway to use to reach the UPF subnet
+    dnn:
+      type: string
+      default: "internet"
+      description: Data Network Name
 
 actions:
   start-simulation:

--- a/src/charm.py
+++ b/src/charm.py
@@ -205,20 +205,20 @@ class GNBSIMOperatorCharm(CharmBase):
                 return
             logger.info("gnbsim simulation output:\n=====\n%s\n=====", stderr)
 
-            log_message = "Profile Status: PASS"
-            count = stderr.count(log_message)
-            if count >= NUM_PROFILES:
+            count = stderr.count("Profile Status: PASS")
+            info = f"Profile Simulation results: {count}/{NUM_PROFILES} profiles passed"
+            if count == NUM_PROFILES:
                 event.set_results(
                     {
                         "success": "true",
-                        "info": f"Log message appeared {count} times, meeting or exceeding the required {NUM_PROFILES} occurrences.",  # noqa: E501
+                        "info": info
                     }
                 )
             else:
                 event.set_results(
                     {
                         "success": "false",
-                        "info": f"Log message appeared {count} times, but {NUM_PROFILES} occurrences were required.",  # noqa: E501
+                        "info": info
                     }
                 )
         except ExecError as e:

--- a/src/charm.py
+++ b/src/charm.py
@@ -164,6 +164,8 @@ class GNBSIMOperatorCharm(CharmBase):
             return
         if not (usim_key := self._get_usim_key_from_config()):
             return
+        if not (dnn := self._get_dnn_from_config()):
+            return
         content = self._render_config_file(
             amf_hostname=self._n2_requirer.amf_hostname,
             amf_port=self._n2_requirer.amf_port,
@@ -178,6 +180,7 @@ class GNBSIMOperatorCharm(CharmBase):
             tac=tac,
             usim_opc=usim_opc,
             usim_key=usim_key,
+            dnn=dnn,
         )
         self._write_config_file(content=content)
         self._update_fiveg_gnb_identity_relation_data()
@@ -314,6 +317,9 @@ class GNBSIMOperatorCharm(CharmBase):
 
     def _get_usim_sequence_number_from_config(self) -> Optional[str]:
         return cast(Optional[str], self.model.config.get("usim-sequence-number"))
+    
+    def _get_dnn_from_config(self) -> Optional[str]:
+        return cast(Optional[str], self.model.config.get("dnn"))
 
     def _get_workload_version(self) -> str:
         """Return the workload version.
@@ -358,6 +364,7 @@ class GNBSIMOperatorCharm(CharmBase):
         usim_key: str,
         usim_opc: str,
         usim_sequence_number: str,
+        dnn: str,
     ) -> str:
         """Render config file based on parameters.
 
@@ -375,6 +382,7 @@ class GNBSIMOperatorCharm(CharmBase):
             usim_key: USIM key
             usim_opc: USIM OPC
             usim_sequence_number: USIM sequence number
+            dnn: Data Network Name
 
         Returns:
             str: Rendered gnbsim configuration file
@@ -395,6 +403,7 @@ class GNBSIMOperatorCharm(CharmBase):
             usim_key=usim_key,
             usim_opc=usim_opc,
             usim_sequence_number=usim_sequence_number,
+            dnn=dnn,
         )
 
     def _get_invalid_configs(self) -> list[str]:  # noqa: C901

--- a/src/charm.py
+++ b/src/charm.py
@@ -40,7 +40,7 @@ N2_RELATION_NAME = "fiveg-n2"
 GNB_IDENTITY_RELATION_NAME = "fiveg_gnb_identity"
 LOGGING_RELATION_NAME = "logging"
 WORKLOAD_VERSION_FILE_NAME = "/etc/workload-version"
-NUM_PROFILES = 3
+NUM_PROFILES = 5
 
 
 class GNBSIMOperatorCharm(CharmBase):

--- a/src/charm.py
+++ b/src/charm.py
@@ -206,7 +206,7 @@ class GNBSIMOperatorCharm(CharmBase):
             logger.info("gnbsim simulation output:\n=====\n%s\n=====", stderr)
 
             count = stderr.count("Profile Status: PASS")
-            info = f"Profile Simulation results: {count}/{NUM_PROFILES} profiles passed"
+            info = f"{count}/{NUM_PROFILES} profiles passed"
             if count == NUM_PROFILES:
                 event.set_results(
                     {

--- a/src/charm.py
+++ b/src/charm.py
@@ -41,6 +41,7 @@ GNB_IDENTITY_RELATION_NAME = "fiveg_gnb_identity"
 LOGGING_RELATION_NAME = "logging"
 WORKLOAD_VERSION_FILE_NAME = "/etc/workload-version"
 
+
 class GNBSIMOperatorCharm(CharmBase):
     """Main class to describe juju event handling for the 5G GNBSIM operator for K8s."""
 
@@ -317,7 +318,7 @@ class GNBSIMOperatorCharm(CharmBase):
 
     def _get_usim_sequence_number_from_config(self) -> Optional[str]:
         return cast(Optional[str], self.model.config.get("usim-sequence-number"))
-    
+
     def _get_dnn_from_config(self) -> Optional[str]:
         return cast(Optional[str], self.model.config.get("dnn"))
 

--- a/src/templates/config.yaml.j2
+++ b/src/templates/config.yaml.j2
@@ -31,6 +31,24 @@ configuration:
   httpServer:
     enable: false
   profiles:
+  - profileType: register
+    profileName: profile1
+    enable: true
+    gnbName: gnb1
+    startImsi: {{ imsi }}
+    ueCount: 1
+    defaultAs: {{ icmp_packet_destination }}
+    opc: {{ usim_opc }}
+    key: {{ usim_key }}
+    sequenceNumber: {{ usim_sequence_number }}
+    dnn: {{ dnn }}
+    sNssai:
+      sst: {{ sst }}
+      sd: "{{ sd }}"
+    execInParallel: false
+    plmnId:
+      mcc: {{ mcc }}
+      mnc: {{ mnc }}
   - dataPktCount: 5
     defaultAs: {{ icmp_packet_destination }}
     enable: true
@@ -42,7 +60,7 @@ configuration:
     plmnId:
       mcc: {{ mcc }}
       mnc: {{ mnc }}
-    profileName: profile1
+    profileName: profile2
     profileType: pdusessest
     sequenceNumber: {{ usim_sequence_number }}
     startImsi: {{ imsi }}

--- a/src/templates/config.yaml.j2
+++ b/src/templates/config.yaml.j2
@@ -49,7 +49,9 @@ configuration:
     plmnId:
       mcc: {{ mcc }}
       mnc: {{ mnc }}
-  - dataPktCount: 5
+  - profileType: pdusessest
+    profileName: profile2
+    dataPktCount: 5
     defaultAs: {{ icmp_packet_destination }}
     enable: true
     execInParallel: false
@@ -57,14 +59,34 @@ configuration:
     key: {{ usim_key }}
     opc: {{ usim_opc }}
     perUserTimeout: 100
+    dnn: "internet"
+    sNssai:
+      sst: {{ sst }}
+      sd: "{{ sd }}"
     plmnId:
       mcc: {{ mcc }}
       mnc: {{ mnc }}
-    profileName: profile2
-    profileType: pdusessest
     sequenceNumber: {{ usim_sequence_number }}
     startImsi: {{ imsi }}
     ueCount: 1
+  - profileType: anrelease
+    profileName: profile3
+    enable: true
+    gnbName: gnb1
+    startImsi: {{ imsi }}
+    ueCount: 1
+    defaultAs: {{ icmp_packet_destination }}
+    opc: {{ usim_opc }}
+    key: {{ usim_key }}
+    sequenceNumber: {{ usim_sequence_number }}
+    dnn: {{ dnn }}
+    sNssai:
+      sst: {{ sst }}
+      sd: "{{ sd }}"
+    execInParallel: false
+    plmnId:
+      mcc: {{ mcc }}
+      mnc: {{ mnc }}
   runConfigProfilesAtStart: true
 info:
   description: gNodeB sim initial configuration

--- a/src/templates/config.yaml.j2
+++ b/src/templates/config.yaml.j2
@@ -87,6 +87,43 @@ configuration:
     plmnId:
       mcc: {{ mcc }}
       mnc: {{ mnc }}
+  - profileType: uetriggservicereq
+    profileName: profile4
+    enable: true
+    gnbName: gnb1
+    startImsi: {{ imsi }}
+    ueCount: 1
+    defaultAs: {{ icmp_packet_destination }}
+    opc: {{ usim_opc }}
+    key: {{ usim_key }}
+    sequenceNumber: {{ usim_sequence_number }}
+    dnn: {{ dnn }}
+    retransMsg: false
+    sNssai:
+      sst: {{ sst }}
+      sd: "{{ sd }}"
+    execInParallel: false
+    plmnId:
+      mcc: {{ mcc }}
+      mnc: {{ mnc }}
+  - profileType: deregister
+    profileName: profile5
+    enable: false
+    gnbName: gnb1
+    startImsi: {{ imsi }}
+    ueCount: 1
+    defaultAs: {{ icmp_packet_destination }}
+    opc: {{ usim_opc }}
+    key: {{ usim_key }}
+    sequenceNumber: {{ usim_sequence_number }}
+    dnn: {{ dnn }}
+    sNssai:
+      sst: {{ sst }}
+      sd: "{{ sd }}"
+    execInParallel: false
+    plmnId:
+      mcc: {{ mcc }}
+      mnc: {{ mnc }}
   runConfigProfilesAtStart: true
 info:
   description: gNodeB sim initial configuration

--- a/src/templates/config.yaml.j2
+++ b/src/templates/config.yaml.j2
@@ -108,7 +108,7 @@ configuration:
       mnc: {{ mnc }}
   - profileType: deregister
     profileName: profile5
-    enable: false
+    enable: true
     gnbName: gnb1
     startImsi: {{ imsi }}
     ueCount: 1

--- a/tests/unit/expected_config.yaml
+++ b/tests/unit/expected_config.yaml
@@ -31,6 +31,24 @@ configuration:
   httpServer:
     enable: false
   profiles:
+  - profileType: register
+    profileName: profile1
+    enable: true
+    gnbName: gnb1
+    startImsi: 001010100007487
+    ueCount: 1
+    defaultAs: 192.168.250.1
+    opc: 981d464c7c52eb6e5036234984ad0bcf
+    key: 5122250214c33e723a5dd523fc145fc0
+    sequenceNumber: 16f3b3f70fc2
+    dnn: internet
+    sNssai:
+      sst: 1
+      sd: "102030"
+    execInParallel: false
+    plmnId:
+      mcc: 001
+      mnc: 01
   - dataPktCount: 5
     defaultAs: 192.168.250.1
     enable: true
@@ -42,7 +60,7 @@ configuration:
     plmnId:
       mcc: 001
       mnc: 01
-    profileName: profile1
+    profileName: profile2
     profileType: pdusessest
     sequenceNumber: 16f3b3f70fc2
     startImsi: 001010100007487

--- a/tests/unit/expected_config.yaml
+++ b/tests/unit/expected_config.yaml
@@ -49,7 +49,9 @@ configuration:
     plmnId:
       mcc: 001
       mnc: 01
-  - dataPktCount: 5
+  - profileType: pdusessest
+    profileName: profile2
+    dataPktCount: 5
     defaultAs: 192.168.250.1
     enable: true
     execInParallel: false
@@ -57,14 +59,34 @@ configuration:
     key: 5122250214c33e723a5dd523fc145fc0
     opc: 981d464c7c52eb6e5036234984ad0bcf
     perUserTimeout: 100
+    dnn: "internet"
+    sNssai:
+      sst: 1
+      sd: "102030"
     plmnId:
       mcc: 001
       mnc: 01
-    profileName: profile2
-    profileType: pdusessest
     sequenceNumber: 16f3b3f70fc2
     startImsi: 001010100007487
     ueCount: 1
+  - profileType: anrelease
+    profileName: profile3
+    enable: true
+    gnbName: gnb1
+    startImsi: 001010100007487
+    ueCount: 1
+    defaultAs: 192.168.250.1
+    opc: 981d464c7c52eb6e5036234984ad0bcf
+    key: 5122250214c33e723a5dd523fc145fc0
+    sequenceNumber: 16f3b3f70fc2
+    dnn: internet
+    sNssai:
+      sst: 1
+      sd: "102030"
+    execInParallel: false
+    plmnId:
+      mcc: 001
+      mnc: 01
   runConfigProfilesAtStart: true
 info:
   description: gNodeB sim initial configuration

--- a/tests/unit/expected_config.yaml
+++ b/tests/unit/expected_config.yaml
@@ -87,6 +87,43 @@ configuration:
     plmnId:
       mcc: 001
       mnc: 01
+  - profileType: uetriggservicereq
+    profileName: profile4
+    enable: true
+    gnbName: gnb1
+    startImsi: 001010100007487
+    ueCount: 1
+    defaultAs: 192.168.250.1
+    opc: 981d464c7c52eb6e5036234984ad0bcf
+    key: 5122250214c33e723a5dd523fc145fc0
+    sequenceNumber: 16f3b3f70fc2
+    dnn: internet
+    retransMsg: false
+    sNssai:
+      sst: 1
+      sd: "102030"
+    execInParallel: false
+    plmnId:
+      mcc: 001
+      mnc: 01
+  - profileType: deregister
+    profileName: profile5
+    enable: false
+    gnbName: gnb1
+    startImsi: 001010100007487
+    ueCount: 1
+    defaultAs: 192.168.250.1
+    opc: 981d464c7c52eb6e5036234984ad0bcf
+    key: 5122250214c33e723a5dd523fc145fc0
+    sequenceNumber: 16f3b3f70fc2
+    dnn: internet
+    sNssai:
+      sst: 1
+      sd: "102030"
+    execInParallel: false
+    plmnId:
+      mcc: 001
+      mnc: 01
   runConfigProfilesAtStart: true
 info:
   description: gNodeB sim initial configuration

--- a/tests/unit/expected_config.yaml
+++ b/tests/unit/expected_config.yaml
@@ -108,7 +108,7 @@ configuration:
       mnc: 01
   - profileType: deregister
     profileName: profile5
-    enable: false
+    enable: true
     gnbName: gnb1
     startImsi: 001010100007487
     ueCount: 1

--- a/tests/unit/test_charm_simulation_action.py
+++ b/tests/unit/test_charm_simulation_action.py
@@ -1,0 +1,125 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+import tempfile
+
+import pytest
+import scenario
+from ops.testing import ActionFailed
+
+from tests.unit.fixtures import GNBSUMUnitTestFixtures
+
+
+class TestCharmStartSimulationAction(GNBSUMUnitTestFixtures):
+    def test_given_config_file_not_written_when_start_simulation_then_action_fails(
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            container = scenario.Container(
+                name="gnbsim",
+                can_connect=True,
+                mounts={
+                    "config": scenario.Mount(
+                        location="/etc/gnbsim",
+                        source=temp_dir,
+                    )
+                },
+                execs={
+                    scenario.Exec(
+                        command_prefix=[
+                            "ip",
+                            "route",
+                            "replace",
+                            "192.168.252.0/24",
+                            "via",
+                            "192.168.251.1",
+                        ]
+                    )
+                },
+            )
+            state_in = scenario.State(
+                leader=True,
+                containers={container},
+            )
+
+            with pytest.raises(ActionFailed) as exc_info:
+                self.ctx.run(self.ctx.on.action("start-simulation"), state_in)
+
+            assert exc_info.value.message == "Config file is not written"
+
+    def test_given_less_than_5_profiles_passed_when_start_simulation_then_action_returns_with_success_false(  # noqa: E501
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            container = scenario.Container(
+                name="gnbsim",
+                can_connect=True,
+                mounts={
+                    "config": scenario.Mount(
+                        location="/etc/gnbsim",
+                        source=temp_dir,
+                    )
+                },
+                execs={
+                    scenario.Exec(
+                        command_prefix=["/bin/gnbsim", "--cfg", "/etc/gnbsim/gnb.conf"],
+                        return_code=0,
+                        stderr="Profile Status: PASS\nProfile Status: PASS\nProfile Status: FAILED\nProfile Status: PASS\nProfile Status: PASS\n",  # noqa: E501
+                    )
+                },
+            )
+            state_in = scenario.State(
+                leader=True,
+                containers={container},
+            )
+
+            with open("tests/unit/expected_config.yaml", "r") as f:
+                config_file = f.read()
+
+            with open(f"{temp_dir}/gnb.conf", "w") as f:
+                f.write(config_file)
+
+            self.ctx.run(self.ctx.on.action("start-simulation"), state_in)
+
+            assert self.ctx.action_results
+            assert self.ctx.action_results["success"] == "false"
+            assert self.ctx.action_results["info"] == "4/5 profiles passed"
+
+    def test_given_5_profiles_passed_when_start_simulation_then_action_returns_with_success(
+        self,
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            container = scenario.Container(
+                name="gnbsim",
+                can_connect=True,
+                mounts={
+                    "config": scenario.Mount(
+                        location="/etc/gnbsim",
+                        source=temp_dir,
+                    )
+                },
+                execs={
+                    scenario.Exec(
+                        command_prefix=["/bin/gnbsim", "--cfg", "/etc/gnbsim/gnb.conf"],
+                        return_code=0,
+                        stderr="Profile Status: PASS\nProfile Status: PASS\nProfile Status: PASS\nProfile Status: PASS\nProfile Status: PASS\n",  # noqa: E501
+                    )
+                },
+            )
+            state_in = scenario.State(
+                leader=True,
+                containers={container},
+            )
+
+            with open("tests/unit/expected_config.yaml", "r") as f:
+                config_file = f.read()
+
+            with open(f"{temp_dir}/gnb.conf", "w") as f:
+                f.write(config_file)
+
+            self.ctx.run(self.ctx.on.action("start-simulation"), state_in)
+
+            assert self.ctx.action_results
+            assert self.ctx.action_results["success"] == "true"
+            assert self.ctx.action_results["info"] == "5/5 profiles passed"


### PR DESCRIPTION
# Description

Here we add additional 5G simulation profiles. Now in total we have:
- **register (new)**: Registration procedure
- **pdusessest (existing)**: Registration + UE initiated PDU Session Establishment + User Data packets
- **deregister (new)**: Registration + UE initiated PDU Session Establishment + User Data packets + Deregister
- **anrelease (new)**: Registration + UE initiated PDU Session Establishment + User Data packets + AN Release
- **uetriggservicereq (new)**: Registration + UE initiated PDU Session Establishment + User Data packets + AN Release + UE Initiated Service Request

## Rationale

Those additional profiles increase the level of confidence in our 5G end to end setup as they traverse additional paths and real life conditions in a 5G network.

## Logs
```
guillaume@thinkpad:~/code/sdcore-gnbsim-rock$ juju run gnbsim3/leader start-simulation
Running operation 12 with 1 task
  - task 13 on unit-gnbsim3-0

Waiting for task 13...
info: 'Profile Simulation results: 5/5 profiles passed'
success: "true"
```

The whole logs for the simulation profile is here.

[5_gnbsim_profiles_success.log](https://github.com/user-attachments/files/17234301/5_gnbsim_profiles_success.log)


## Reference
- https://github.com/omec-project/gnbsim/blob/main/config/gnbsim.yaml
- https://github.com/omec-project/gnbsim/blob/main/docs/config.md

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library