### PR TITLE
chore: use built-in testing from ops

### DIFF
--- a/test-requirements.in
+++ b/test-requirements.in
@@ -6,4 +6,3 @@ pytest
 pytest-asyncio>=v0.21.2  # https://github.com/pytest-dev/pytest/issues/12269
 pytest-operator
 ruff
-ops-scenario

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,119 +7,164 @@
 asttokens==2.4.1
     # via stack-data
 bcrypt==4.2.0
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 cachetools==5.5.0
-    # via google-auth
+    # via
+    #   -c requirements.txt
+    #   google-auth
 certifi==2024.8.30
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 cffi==1.17.1
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 codespell==2.3.0
     # via -r test-requirements.in
-coverage[toml]==7.6.1
+coverage[toml]==7.6.2
     # via -r test-requirements.in
 cryptography==43.0.1
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
 durationpy==0.7
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 executing==2.1.0
     # via stack-data
 google-auth==2.35.0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 hvac==2.3.0
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 idna==3.10
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 iniconfig==2.0.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 ipdb==0.13.13
     # via pytest-operator
-ipython==8.27.0
+ipython==8.28.0
     # via ipdb
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 juju==3.5.2.0
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   pytest-operator
 kubernetes==31.0.0
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 macaroonbakery==1.3.4
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements.txt
+    #   jinja2
 matplotlib-inline==0.1.7
     # via ipython
 mypy-extensions==1.0.0
-    # via typing-inspect
+    # via
+    #   -c requirements.txt
+    #   typing-inspect
 nodeenv==1.9.1
     # via pyright
 oauthlib==3.2.2
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests-oauthlib
-ops==2.17.0
-    # via ops-scenario
-ops-scenario==7.0.5
-    # via -r test-requirements.in
 packaging==24.1
     # via
+    #   -c requirements.txt
     #   juju
     #   pytest
 paramiko==3.5.0
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 parso==0.8.4
     # via jedi
 pexpect==4.9.0
     # via ipython
 pluggy==1.5.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 prompt-toolkit==3.0.48
     # via ipython
 protobuf==5.28.2
-    # via macaroonbakery
+    # via
+    #   -c requirements.txt
+    #   macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
 pyasn1==0.6.1
     # via
+    #   -c requirements.txt
     #   juju
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.4.1
-    # via google-auth
+    # via
+    #   -c requirements.txt
+    #   google-auth
 pycparser==2.22
-    # via cffi
+    # via
+    #   -c requirements.txt
+    #   cffi
 pygments==2.18.0
     # via ipython
 pymacaroons==0.13.0
-    # via macaroonbakery
+    # via
+    #   -c requirements.txt
+    #   macaroonbakery
 pynacl==1.5.0
     # via
+    #   -c requirements.txt
     #   macaroonbakery
     #   paramiko
     #   pymacaroons
 pyrfc3339==1.1
     # via
+    #   -c requirements.txt
     #   juju
     #   macaroonbakery
-pyright==1.1.383
+pyright==1.1.384
     # via -r test-requirements.in
 pytest==8.3.3
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   pytest-asyncio
     #   pytest-operator
@@ -130,30 +175,39 @@ pytest-asyncio==0.21.2
 pytest-operator==0.38.0
     # via -r test-requirements.in
 python-dateutil==2.9.0.post0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 pytz==2024.2
-    # via pyrfc3339
+    # via
+    #   -c requirements.txt
+    #   pyrfc3339
 pyyaml==6.0.2
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
-    #   ops
-    #   ops-scenario
     #   pytest-operator
 requests==2.32.3
     # via
+    #   -c requirements.txt
     #   hvac
     #   kubernetes
     #   macaroonbakery
     #   requests-oauthlib
 requests-oauthlib==2.0.0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 rsa==4.9
-    # via google-auth
-ruff==0.6.8
+    # via
+    #   -c requirements.txt
+    #   google-auth
+ruff==0.6.9
     # via -r test-requirements.in
 six==1.16.0
     # via
+    #   -c requirements.txt
     #   asttokens
     #   kubernetes
     #   macaroonbakery
@@ -162,26 +216,34 @@ six==1.16.0
 stack-data==0.6.3
     # via ipython
 toposort==1.10
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
 typing-extensions==4.12.2
     # via
+    #   -c requirements.txt
     #   pyright
     #   typing-inspect
 typing-inspect==0.9.0
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 urllib3==2.2.3
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.8.0
     # via
+    #   -c requirements.txt
     #   kubernetes
-    #   ops
 websockets==13.1
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -4,7 +4,7 @@
 from unittest.mock import PropertyMock, patch
 
 import pytest
-import scenario
+from ops import testing
 
 from charm import GNBSIMOperatorCharm
 
@@ -42,6 +42,6 @@ class GNBSUMUnitTestFixtures:
 
     @pytest.fixture(autouse=True)
     def context(self):
-        self.ctx = scenario.Context(
+        self.ctx = testing.Context(
             charm_type=GNBSIMOperatorCharm,
         )

--- a/tests/unit/lib/charms/sdcore_gnbsim/v0/test_fiveg_gnb_indentity_provider.py
+++ b/tests/unit/lib/charms/sdcore_gnbsim/v0/test_fiveg_gnb_indentity_provider.py
@@ -3,7 +3,7 @@
 
 
 import pytest
-import scenario
+from ops import testing
 from ops.charm import ActionEvent, CharmBase
 
 from lib.charms.sdcore_gnbsim_k8s.v0.fiveg_gnb_identity import GnbIdentityProvides
@@ -35,7 +35,7 @@ class DummyFivegGNBIdentityProviderCharm(CharmBase):
 class TestFiveGGNBIdentityProvider:
     @pytest.fixture(autouse=True)
     def context(self):
-        self.ctx = scenario.Context(
+        self.ctx = testing.Context(
             charm_type=DummyFivegGNBIdentityProviderCharm,
             meta={
                 "name": "gnb-identity-provider-charm",
@@ -55,11 +55,11 @@ class TestFiveGGNBIdentityProvider:
     def test_given_unit_is_leader_and_data_is_valid_when_set_fiveg_gnb_identity_information_then_data_is_in_application_databag(  # noqa: E501
         self,
     ):
-        fiveg_gnb_identity_relation = scenario.Relation(
+        fiveg_gnb_identity_relation = testing.Relation(
             endpoint="fiveg_gnb_identity",
             interface="fiveg_gnb_identity",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations=[fiveg_gnb_identity_relation],
         )
@@ -79,11 +79,11 @@ class TestFiveGGNBIdentityProvider:
         assert relation.local_app_data["tac"] == "1"
 
     def test_given_invalid_gnb_name_when_relation_created_then_value_error_is_raised(self):
-        fiveg_gnb_identity_relation = scenario.Relation(
+        fiveg_gnb_identity_relation = testing.Relation(
             endpoint="fiveg_gnb_identity",
             interface="fiveg_gnb_identity",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations=[fiveg_gnb_identity_relation],
         )

--- a/tests/unit/lib/charms/sdcore_gnbsim/v0/test_fiveg_gnb_indentity_requirer.py
+++ b/tests/unit/lib/charms/sdcore_gnbsim/v0/test_fiveg_gnb_indentity_requirer.py
@@ -3,7 +3,7 @@
 
 
 import pytest
-import scenario
+from ops import testing
 from ops.charm import CharmBase
 
 from lib.charms.sdcore_gnbsim_k8s.v0.fiveg_gnb_identity import (
@@ -23,7 +23,7 @@ class DummyFivegGNBIdentityRequirerCharm(CharmBase):
 class TestFiveGGNBIdentityProvider:
     @pytest.fixture(autouse=True)
     def context(self):
-        self.ctx = scenario.Context(
+        self.ctx = testing.Context(
             charm_type=DummyFivegGNBIdentityRequirerCharm,
             meta={
                 "name": "gnb-identity-requirer-charm",
@@ -34,7 +34,7 @@ class TestFiveGGNBIdentityProvider:
     def test_given_valid_relation_data_when_relation_changed_then_gnb_identity_available_event_is_emitted(  # noqa: E501
         self,
     ):
-        fiveg_gnb_identity_relation = scenario.Relation(
+        fiveg_gnb_identity_relation = testing.Relation(
             endpoint="fiveg_gnb_identity",
             interface="fiveg_gnb_identity",
             remote_app_data={
@@ -42,7 +42,7 @@ class TestFiveGGNBIdentityProvider:
                 "gnb_name": "gnb",
             },
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations=[fiveg_gnb_identity_relation],
         )
@@ -57,14 +57,14 @@ class TestFiveGGNBIdentityProvider:
     def test_given_invalid_relation_data_when_relation_changed_then_gnb_identity_available_event_not_emitted(  # noqa: E501
         self,
     ):
-        fiveg_gnb_identity_relation = scenario.Relation(
+        fiveg_gnb_identity_relation = testing.Relation(
             endpoint="fiveg_gnb_identity",
             interface="fiveg_gnb_identity",
             remote_app_data={
                 "tac": "1",
             },
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations=[fiveg_gnb_identity_relation],
         )

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -5,8 +5,7 @@
 import tempfile
 
 import pytest
-import scenario
-from ops import ActiveStatus, BlockedStatus, WaitingStatus
+from ops import ActiveStatus, BlockedStatus, WaitingStatus, testing
 
 from tests.unit.fixtures import GNBSUMUnitTestFixtures
 
@@ -32,7 +31,7 @@ class TestCharmCollectUnitStatus(GNBSUMUnitTestFixtures):
     def test_given_invalid_config_when_collect_unit_status_then_status_is_blocked(
         self, config_param
     ):
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             config={config_param: ""},
         )
@@ -44,7 +43,7 @@ class TestCharmCollectUnitStatus(GNBSUMUnitTestFixtures):
         )
 
     def test_given_n2_relation_not_created_when_collect_unit_status_then_status_is_waiting(self):
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
         )
 
@@ -53,18 +52,18 @@ class TestCharmCollectUnitStatus(GNBSUMUnitTestFixtures):
         assert state_out.unit_status == BlockedStatus("Waiting for N2 relation to be created")
 
     def test_given_cant_connect_to_workload_when_collect_unit_status_then_status_is_waiting(self):
-        n2_relation = scenario.Relation(endpoint="fiveg-n2", interface="fiveg_n2")
-        container = scenario.Container(name="gnbsim", can_connect=False)
-        state_in = scenario.State(leader=True, relations=[n2_relation], containers=[container])
+        n2_relation = testing.Relation(endpoint="fiveg-n2", interface="fiveg_n2")
+        container = testing.Container(name="gnbsim", can_connect=False)
+        state_in = testing.State(leader=True, relations=[n2_relation], containers=[container])
 
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
 
         assert state_out.unit_status == WaitingStatus("Waiting for container to be ready")
 
     def test_given_storage_not_attached_when_collect_unit_status_then_status_is_waiting(self):
-        n2_relation = scenario.Relation(endpoint="fiveg-n2", interface="fiveg_n2")
-        container = scenario.Container(name="gnbsim", can_connect=True)
-        state_in = scenario.State(leader=True, relations=[n2_relation], containers=[container])
+        n2_relation = testing.Relation(endpoint="fiveg-n2", interface="fiveg_n2")
+        container = testing.Container(name="gnbsim", can_connect=True)
+        state_in = testing.State(leader=True, relations=[n2_relation], containers=[container])
 
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
 
@@ -72,18 +71,18 @@ class TestCharmCollectUnitStatus(GNBSUMUnitTestFixtures):
 
     def test_given_multus_not_available_when_collect_unit_status_then_status_is_waiting(self):
         self.mock_k8s_multus.multus_is_available.return_value = False
-        n2_relation = scenario.Relation(endpoint="fiveg-n2", interface="fiveg_n2")
-        container = scenario.Container(
+        n2_relation = testing.Relation(endpoint="fiveg-n2", interface="fiveg_n2")
+        container = testing.Container(
             name="gnbsim",
             can_connect=True,
             mounts={
-                "config": scenario.Mount(
+                "config": testing.Mount(
                     location="/etc/gnbsim",
                     source=tempfile.mkdtemp(),
                 )
             },
         )
-        state_in = scenario.State(leader=True, relations=[n2_relation], containers=[container])
+        state_in = testing.State(leader=True, relations=[n2_relation], containers=[container])
 
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
 
@@ -92,18 +91,18 @@ class TestCharmCollectUnitStatus(GNBSUMUnitTestFixtures):
     def test_given_multus_not_ready_when_collect_unit_status_then_status_is_waiting(self):
         self.mock_k8s_multus.multus_is_available.return_value = True
         self.mock_k8s_multus.is_ready.return_value = False
-        n2_relation = scenario.Relation(endpoint="fiveg-n2", interface="fiveg_n2")
-        container = scenario.Container(
+        n2_relation = testing.Relation(endpoint="fiveg-n2", interface="fiveg_n2")
+        container = testing.Container(
             name="gnbsim",
             can_connect=True,
             mounts={
-                "config": scenario.Mount(
+                "config": testing.Mount(
                     location="/etc/gnbsim",
                     source=tempfile.mkdtemp(),
                 )
             },
         )
-        state_in = scenario.State(leader=True, relations=[n2_relation], containers=[container])
+        state_in = testing.State(leader=True, relations=[n2_relation], containers=[container])
 
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
 
@@ -116,18 +115,18 @@ class TestCharmCollectUnitStatus(GNBSUMUnitTestFixtures):
         self.mock_k8s_multus.is_ready.return_value = True
         self.mock_n2_requirer_amf_hostname.return_value = None
         self.mock_n2_requirer_amf_port.return_value = None
-        n2_relation = scenario.Relation(endpoint="fiveg-n2", interface="fiveg_n2")
-        container = scenario.Container(
+        n2_relation = testing.Relation(endpoint="fiveg-n2", interface="fiveg_n2")
+        container = testing.Container(
             name="gnbsim",
             can_connect=True,
             mounts={
-                "config": scenario.Mount(
+                "config": testing.Mount(
                     location="/etc/gnbsim",
                     source=tempfile.mkdtemp(),
                 )
             },
         )
-        state_in = scenario.State(leader=True, relations=[n2_relation], containers=[container])
+        state_in = testing.State(leader=True, relations=[n2_relation], containers=[container])
 
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
 
@@ -138,18 +137,18 @@ class TestCharmCollectUnitStatus(GNBSUMUnitTestFixtures):
         self.mock_k8s_multus.is_ready.return_value = True
         self.mock_n2_requirer_amf_hostname.return_value = "amf"
         self.mock_n2_requirer_amf_port.return_value = 1234
-        n2_relation = scenario.Relation(endpoint="fiveg-n2", interface="fiveg_n2")
-        container = scenario.Container(
+        n2_relation = testing.Relation(endpoint="fiveg-n2", interface="fiveg_n2")
+        container = testing.Container(
             name="gnbsim",
             can_connect=True,
             mounts={
-                "config": scenario.Mount(
+                "config": testing.Mount(
                     location="/etc/gnbsim",
                     source=tempfile.mkdtemp(),
                 )
             },
         )
-        state_in = scenario.State(leader=True, relations=[n2_relation], containers=[container])
+        state_in = testing.State(leader=True, relations=[n2_relation], containers=[container])
 
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
 

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -4,7 +4,7 @@
 
 import tempfile
 
-import scenario
+from ops import testing
 
 from tests.unit.fixtures import GNBSUMUnitTestFixtures
 
@@ -18,18 +18,18 @@ class TestCharmConfigure(GNBSUMUnitTestFixtures):
             self.mock_k8s_multus.is_ready.return_value = True
             self.mock_n2_requirer_amf_hostname.return_value = "amf"
             self.mock_n2_requirer_amf_port.return_value = 38412
-            n2_relation = scenario.Relation(endpoint="fiveg-n2", interface="fiveg_n2")
-            container = scenario.Container(
+            n2_relation = testing.Relation(endpoint="fiveg-n2", interface="fiveg_n2")
+            container = testing.Container(
                 name="gnbsim",
                 can_connect=True,
                 mounts={
-                    "config": scenario.Mount(
+                    "config": testing.Mount(
                         location="/etc/gnbsim",
                         source=temp_dir,
                     )
                 },
                 execs={
-                    scenario.Exec(
+                    testing.Exec(
                         command_prefix=[
                             "ip",
                             "route",
@@ -41,7 +41,7 @@ class TestCharmConfigure(GNBSUMUnitTestFixtures):
                     )
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[n2_relation],
                 containers=[container],
@@ -63,21 +63,21 @@ class TestCharmConfigure(GNBSUMUnitTestFixtures):
             self.mock_k8s_multus.is_ready.return_value = True
             self.mock_n2_requirer_amf_hostname.return_value = "amf"
             self.mock_n2_requirer_amf_port.return_value = 38412
-            n2_relation = scenario.Relation(endpoint="fiveg-n2", interface="fiveg_n2")
-            gnb_identity_relation = scenario.Relation(
+            n2_relation = testing.Relation(endpoint="fiveg-n2", interface="fiveg_n2")
+            gnb_identity_relation = testing.Relation(
                 endpoint="fiveg_gnb_identity", interface="fiveg_gnb_identity"
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="gnbsim",
                 can_connect=True,
                 mounts={
-                    "config": scenario.Mount(
+                    "config": testing.Mount(
                         location="/etc/gnbsim",
                         source=temp_dir,
                     )
                 },
                 execs={
-                    scenario.Exec(
+                    testing.Exec(
                         command_prefix=[
                             "ip",
                             "route",
@@ -89,11 +89,11 @@ class TestCharmConfigure(GNBSUMUnitTestFixtures):
                     )
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations=[n2_relation, gnb_identity_relation],
                 containers=[container],
-                model=scenario.Model(name="my-model"),
+                model=testing.Model(name="my-model"),
                 config={"tac": "2"},
             )
 

--- a/tests/unit/test_charm_remove.py
+++ b/tests/unit/test_charm_remove.py
@@ -3,18 +3,18 @@
 # See LICENSE file for licensing details.
 
 
-import scenario
+from ops import testing
 
 from tests.unit.fixtures import GNBSUMUnitTestFixtures
 
 
 class TestCharmRemove(GNBSUMUnitTestFixtures):
     def test_given_unit_is_leader_when_remove_then_k8s_multus_is_removed(self):
-        container = scenario.Container(
+        container = testing.Container(
             name="gnbsim",
             can_connect=False,
         )
-        state_in = scenario.State(leader=True, containers=[container])
+        state_in = testing.State(leader=True, containers=[container])
 
         self.ctx.run(self.ctx.on.remove(), state_in)
 

--- a/tests/unit/test_charm_simulation_action.py
+++ b/tests/unit/test_charm_simulation_action.py
@@ -5,7 +5,7 @@
 import tempfile
 
 import pytest
-import scenario
+from ops import testing
 from ops.testing import ActionFailed
 
 from tests.unit.fixtures import GNBSUMUnitTestFixtures
@@ -16,17 +16,17 @@ class TestCharmStartSimulationAction(GNBSUMUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            container = scenario.Container(
+            container = testing.Container(
                 name="gnbsim",
                 can_connect=True,
                 mounts={
-                    "config": scenario.Mount(
+                    "config": testing.Mount(
                         location="/etc/gnbsim",
                         source=temp_dir,
                     )
                 },
                 execs={
-                    scenario.Exec(
+                    testing.Exec(
                         command_prefix=[
                             "ip",
                             "route",
@@ -38,7 +38,7 @@ class TestCharmStartSimulationAction(GNBSUMUnitTestFixtures):
                     )
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers={container},
             )
@@ -52,24 +52,24 @@ class TestCharmStartSimulationAction(GNBSUMUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            container = scenario.Container(
+            container = testing.Container(
                 name="gnbsim",
                 can_connect=True,
                 mounts={
-                    "config": scenario.Mount(
+                    "config": testing.Mount(
                         location="/etc/gnbsim",
                         source=temp_dir,
                     )
                 },
                 execs={
-                    scenario.Exec(
+                    testing.Exec(
                         command_prefix=["/bin/gnbsim", "--cfg", "/etc/gnbsim/gnb.conf"],
                         return_code=0,
                         stderr="Profile Status: PASS\nProfile Status: PASS\nProfile Status: FAILED\nProfile Status: PASS\nProfile Status: PASS\n",  # noqa: E501
                     )
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers={container},
             )
@@ -90,24 +90,24 @@ class TestCharmStartSimulationAction(GNBSUMUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            container = scenario.Container(
+            container = testing.Container(
                 name="gnbsim",
                 can_connect=True,
                 mounts={
-                    "config": scenario.Mount(
+                    "config": testing.Mount(
                         location="/etc/gnbsim",
                         source=temp_dir,
                     )
                 },
                 execs={
-                    scenario.Exec(
+                    testing.Exec(
                         command_prefix=["/bin/gnbsim", "--cfg", "/etc/gnbsim/gnb.conf"],
                         return_code=0,
                         stderr="Profile Status: PASS\nProfile Status: PASS\nProfile Status: PASS\nProfile Status: PASS\nProfile Status: PASS\n",  # noqa: E501
                     )
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers={container},
             )


### PR DESCRIPTION
# Description

Now that scenario testing is built into ops we don't need to import it as a separate dependency. Here we use ops.testing instead of scenario. Both have the same API.


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library