### PR TITLE
feat: replace fiveg_gnb_identity with fiveg_core_gnb

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -71,28 +71,3 @@ jobs:
       track-name: 1.6
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
-
-  fiveg-gnb-identity-lib-needs-publishing:
-    runs-on: ubuntu-24.04
-    outputs:
-      needs-publishing: ${{ steps.changes.outputs.fiveg_gnb_identity }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-            fiveg_gnb_identity:
-              - 'lib/charms/sdcore_gnbsim_k8s/v0/fiveg_gnb_identity.py'
-
-  publish-fiveg-gnb-identity-lib:
-    name: Publish Lib
-    needs:
-      - publish-charm
-      - fiveg-gnb-identity-lib-needs-publishing
-    if: ${{ github.ref_name == 'main' }}
-    uses: canonical/sdcore-github-workflows/.github/workflows/publish-lib.yaml@v2.3.0
-    with:
-      lib-name: "charms.sdcore_gnbsim_k8s.v0.fiveg_gnb_identity"
-    secrets:
-      CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -13,8 +13,8 @@ output "requires" {
   }
 }
 
-output "provides" {
+output "requires" {
   value = {
-    fiveg_gnb_identity = "fiveg_gnb_identity"
+    fiveg_core_gnb = "fiveg_core_gnb"
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -8,8 +8,8 @@ output "app_name" {
 
 output "requires" {
   value = {
-    fiveg_n2 = "fiveg-n2"
-    logging  = "logging"
     fiveg_core_gnb = "fiveg_core_gnb"
+    fiveg_n2       = "fiveg-n2"
+    logging        = "logging"
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -10,11 +10,6 @@ output "requires" {
   value = {
     fiveg_n2 = "fiveg-n2"
     logging  = "logging"
-  }
-}
-
-output "requires" {
-  value = {
     fiveg_core_gnb = "fiveg_core_gnb"
   }
 }


### PR DESCRIPTION
# Description

This PR removes the job that publishes the `fiveg_gnb_identity` library which was removed [here](https://github.com/canonical/sdcore-gnbsim-k8s-operator/pull/372)
It also update the TF modules.
These are leftover of https://github.com/canonical/sdcore-gnbsim-k8s-operator/pull/372

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library