### PR TITLE
fix: use AMF mock to remove cyclic dependency in integration tests

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -72,7 +72,6 @@ class GNBSIMOperatorCharm(CharmBase):
         self.framework.observe(self.on.start_simulation_action, self._on_start_simulation_action)
         self.framework.observe(self.on.fiveg_n2_relation_joined, self._configure)
         self.framework.observe(self._n2_requirer.on.n2_information_available, self._configure)
-        self.framework.observe(self.on[CORE_GNB_RELATION_NAME].relation_created, self._configure)
         self.framework.observe(self.on[CORE_GNB_RELATION_NAME].relation_changed, self._configure)
         self.framework.observe(self.on.remove, self._on_remove)
 

--- a/tests/integration/fiveg_core_gnb_mock_charm.py
+++ b/tests/integration/fiveg_core_gnb_mock_charm.py
@@ -1,0 +1,26 @@
+from any_charm_base import AnyCharmBase  # type: ignore[import]
+from fiveg_core_gnb import FivegCoreGnbProvides, PLMNConfig  # type: ignore[import]
+from ops.framework import EventBase, logger
+
+CORE_GNB_RELATION_NAME = "provide-fiveg-core-gnb"
+
+class AnyCharm(AnyCharmBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._fiveg_core_gnb_provider = FivegCoreGnbProvides(self, CORE_GNB_RELATION_NAME)
+        self.framework.observe(
+            self.on[CORE_GNB_RELATION_NAME].relation_changed,
+            self.fiveg_core_gnb_relation_changed,
+        )
+
+    def fiveg_core_gnb_relation_changed(self, event: EventBase):
+        core_gnb_relations = self.model.relations.get(CORE_GNB_RELATION_NAME)
+        if not core_gnb_relations:
+            logger.info("No %s relations found.", CORE_GNB_RELATION_NAME)
+            return
+        for relation in core_gnb_relations:
+            self._fiveg_core_gnb_provider.publish_gnb_config_information(
+                relation_id=relation.id,
+                tac=1,
+                plmns=[PLMNConfig(mcc="001", mnc="01", sst=1, sd=1056816)],
+            )

--- a/tests/integration/fiveg_n2_mock_charm.py
+++ b/tests/integration/fiveg_n2_mock_charm.py
@@ -1,0 +1,24 @@
+from any_charm_base import AnyCharmBase  # type: ignore[import]
+from fiveg_n2 import N2Provides  # type: ignore[import]
+from ops.framework import EventBase, logger
+
+N2_RELATION_NAME = "provide-fiveg-n2"
+
+class AnyCharm(AnyCharmBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.n2_provider = N2Provides(self, N2_RELATION_NAME)
+        self.framework.observe(
+            self.on[N2_RELATION_NAME].relation_changed,
+            self.fiveg_n2_relation_changed,
+        )
+    def fiveg_n2_relation_changed(self, event: EventBase) -> None:
+        fiveg_n2_relations = self.model.relations.get(N2_RELATION_NAME)
+        if not fiveg_n2_relations:
+            logger.info("No %s relations found.", N2_RELATION_NAME)
+            return
+        self.n2_provider.set_n2_information(
+            amf_ip_address="1.2.3.4",
+            amf_hostname="amf-external.sdcore.svc.cluster.local",
+            amf_port=38412,
+        )


### PR DESCRIPTION
# Description

There’s a cyclic dependency in the integration tests of AMF, NMS, NRF and GNBSIM which makes bumping release version and publishing very difficult, because the charms depend on each other.

This PR together with https://github.com/canonical/sdcore-nms-k8s-operator/pull/407 removes this dependency

![image](https://github.com/user-attachments/assets/115c83b7-15eb-4d78-80de-e393fe14cf00)

Replacing the AMF with a mock, simplifies the integration test. We are able to remove the NRF, DB and TLS charms which in fact do not interact with the gnbsim

To mock the AMF we use [any_charm](https://github.com/canonical/any-charm). The `fiveg_n2` integration was added [here](https://github.com/canonical/any-charm/pull/33)

## BEFORE

![image](https://github.com/user-attachments/assets/724e023b-b4de-4023-a063-8872285e61d7)

## AFTER

![image](https://github.com/user-attachments/assets/71578e20-d50d-4183-9d0a-1cce251ae356)

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library