### PR TITLE
fix: check action stdout to evaluate simulation success

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -22,7 +22,7 @@ resources:
   gnbsim-image:
     type: oci-image
     description: OCI image for 5G gnbsim
-    upstream-source: ghcr.io/canonical/sdcore-gnbsim:1.4.5
+    upstream-source: ghcr.io/canonical/sdcore-gnbsim:1.6.0
 
 storage:
   config:

--- a/src/charm.py
+++ b/src/charm.py
@@ -199,15 +199,19 @@ class GNBSIMOperatorCharm(CharmBase):
             event.fail(message="Config file is not written")
             return
         try:
-            _, stderr = self._exec_command_in_workload(
+            stdout, stderr = self._exec_command_in_workload(
                 command=f"/bin/gnbsim --cfg {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",
             )
-            if not stderr:
+            if stderr:
+                event.fail(message=f"Execution failed with: {str(stderr)}")
+                return
+
+            if not stdout:
                 event.fail(message="No output in simulation")
                 return
-            logger.info("gnbsim simulation output:\n=====\n%s\n=====", stderr)
 
-            count = stderr.count("Profile Status: PASS")
+            logger.info("gnbsim simulation output:\n=====\n%s\n=====", stdout)
+            count = stdout.count("Profile Status: PASS")
             info = f"{count}/{NUM_PROFILES} profiles passed"
             if count == NUM_PROFILES:
                 event.set_results({"success": "true", "info": info})

--- a/src/templates/config.yaml.j2
+++ b/src/templates/config.yaml.j2
@@ -129,4 +129,4 @@ info:
   description: gNodeB sim initial configuration
   version: 1.0.0
 logger:
-  logLevel: trace
+  logLevel: debug

--- a/tests/unit/expected_config.yaml
+++ b/tests/unit/expected_config.yaml
@@ -129,4 +129,4 @@ info:
   description: gNodeB sim initial configuration
   version: 1.0.0
 logger:
-  logLevel: trace
+  logLevel: debug


### PR DESCRIPTION
# Description

For GNBSIM release 1.5.0 and higher versions (https://github.com/omec-project/gnbsim/releases/tag/v1.5.0), 
start simulation action outputs are logged under stdout (not stderr). 
Replaces unsupported log level in the configuration template with a supported one. (trace -> debug) 

Fixes: https://github.com/canonical/sdcore-gnbsim-k8s-operator/issues/374

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library