### PR TITLE
fix: check action stdout to evaluate simulation success

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -23,6 +23,7 @@ resources:
     type: oci-image
     description: OCI image for 5G gnbsim
     upstream-source: ghcr.io/canonical/sdcore-gnbsim:1.5.0
+
 storage:
   config:
     type: filesystem

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -23,7 +23,6 @@ resources:
     type: oci-image
     description: OCI image for 5G gnbsim
     upstream-source: ghcr.io/canonical/sdcore-gnbsim:1.5.0
-
 storage:
   config:
     type: filesystem

--- a/src/charm.py
+++ b/src/charm.py
@@ -196,15 +196,19 @@ class GNBSIMOperatorCharm(CharmBase):
             event.fail(message="Config file is not written")
             return
         try:
-            _, stderr = self._exec_command_in_workload(
+            stdout, stderr = self._exec_command_in_workload(
                 command=f"/bin/gnbsim --cfg {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",
             )
-            if not stderr:
+            if stderr:
+                event.fail(message=f"Execution failed with: {str(stderr)}")
+                return
+
+            if not stdout:
                 event.fail(message="No output in simulation")
                 return
-            logger.info("gnbsim simulation output:\n=====\n%s\n=====", stderr)
 
-            count = stderr.count("Profile Status: PASS")
+            logger.info("gnbsim simulation output:\n=====\n%s\n=====", stdout)
+            count = stdout.count("Profile Status: PASS")
             info = f"{count}/{NUM_PROFILES} profiles passed"
             if count == NUM_PROFILES:
                 event.set_results({"success": "true", "info": info})

--- a/src/templates/config.yaml.j2
+++ b/src/templates/config.yaml.j2
@@ -129,5 +129,5 @@ info:
   description: gNodeB sim initial configuration
   version: 1.0.0
 logger:
-  logLevel: debug
+  logLevel: info
 

--- a/src/templates/config.yaml.j2
+++ b/src/templates/config.yaml.j2
@@ -130,3 +130,4 @@ info:
   version: 1.0.0
 logger:
   logLevel: debug
+

--- a/src/templates/config.yaml.j2
+++ b/src/templates/config.yaml.j2
@@ -129,4 +129,4 @@ info:
   description: gNodeB sim initial configuration
   version: 1.0.0
 logger:
-  logLevel: trace
+  logLevel: debug

--- a/tests/unit/expected_config.yaml
+++ b/tests/unit/expected_config.yaml
@@ -129,4 +129,4 @@ info:
   description: gNodeB sim initial configuration
   version: 1.0.0
 logger:
-  logLevel: debug
+  logLevel: info

--- a/tests/unit/expected_config.yaml
+++ b/tests/unit/expected_config.yaml
@@ -129,4 +129,4 @@ info:
   description: gNodeB sim initial configuration
   version: 1.0.0
 logger:
-  logLevel: trace
+  logLevel: debug


### PR DESCRIPTION
# Description

For GNBSIM release 1.5.0 and higher versions (https://github.com/omec-project/gnbsim/releases/tag/v1.5.0),
start simulation action outputs are logged under stdout (not stderr).
Replaces unsupported log level in the configuration template with a supported one. (trace -> info)

Fixes: https://github.com/canonical/sdcore-gnbsim-k8s-operator/issues/374

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library