### PR TITLE
fix: Uses ubuntu@24.04 in TF module and itests

### DIFF
--- a/src/templates/config.yaml.j2
+++ b/src/templates/config.yaml.j2
@@ -59,7 +59,7 @@ configuration:
     key: {{ usim_key }}
     opc: {{ usim_opc }}
     perUserTimeout: 100
-    dnn: "internet"
+    dnn: {{ dnn }}
     sNssai:
       sst: {{ sst }}
       sd: "{{ sd }}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,6 +9,7 @@ resource "juju_application" "gnbsim" {
     name     = "sdcore-gnbsim-k8s"
     channel  = var.channel
     revision = var.revision
+    base     = var.base
   }
 
   config      = var.config

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -43,6 +43,12 @@ variable "revision" {
   default     = null
 }
 
+variable "base" {
+  description = "The operating system on which to deploy"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "units" {
   description = "Number of units to deploy"
   type        = number

--- a/tests/unit/expected_config.yaml
+++ b/tests/unit/expected_config.yaml
@@ -59,7 +59,7 @@ configuration:
     key: 5122250214c33e723a5dd523fc145fc0
     opc: 981d464c7c52eb6e5036234984ad0bcf
     perUserTimeout: 100
-    dnn: "internet"
+    dnn: internet
     sNssai:
       sst: 1
       sd: "102030"


### PR DESCRIPTION
# Description

This PR fixes [TELCO-1544](https://warthogs.atlassian.net/browse/TELCO-1544)

CONTEXT:
By default, Juju fetches charms with base matching the host OS. It means that when running Jammy, Juju won’t use latest charms, because we’ve changed the base to Noble. 

Adding an optional (as per CC006) config param base will allow using Noble (base should be set to `ubuntu@24.04`) regardless of the host OS.

Enforcing Noble on a Juju model configuration level is not an option, because it breaks COS integration (COS charms are not available in ubuntu@24.04

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library

[TELCO-1544]: https://warthogs.atlassian.net/browse/TELCO-1544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ