### PR TITLE
feat: add ability to configure subscriber count

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -107,7 +107,7 @@ config:
       default: "internet"
       description: Data Network Name
     subscriber-count:
-      type: integer
+      type: int
       default: 1
       description: Number of subscribers to simulate
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -107,7 +107,7 @@ config:
       default: "internet"
       description: Data Network Name
     subscriber-count:
-      type: int
+      type: integer
       default: 1
       description: Number of subscribers to simulate
 
@@ -116,6 +116,6 @@ actions:
     description: Starts gNB simulation
     params:
       timeout:
-        type: int
+        type: integer
         description: Time to wait for the simulation to complete (in seconds). The more subscribers, the longer the simulation will take.
         default: 300

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -81,7 +81,7 @@ config:
     imsi:
       type: string
       default: "001010100007487"
-      description: International Mobile Subscriber Identity
+      description: International Mobile Subscriber Identity. If the subscriber count is greater than 1, the imsi will be incremented by 1 for each subscriber.
     usim-key:
       type: string
       default: "5122250214c33e723a5dd523fc145fc0"
@@ -106,7 +106,16 @@ config:
       type: string
       default: "internet"
       description: Data Network Name
+    subscriber-count:
+      type: int
+      default: 1
+      description: Number of subscribers to simulate
 
 actions:
   start-simulation:
     description: Starts gNB simulation
+    params:
+      timeout:
+        type: int
+        description: Time to wait for the simulation to complete (in seconds). The more subscribers, the longer the simulation will take.
+        default: 300

--- a/src/templates/config.yaml.j2
+++ b/src/templates/config.yaml.j2
@@ -36,7 +36,7 @@ configuration:
     enable: true
     gnbName: gnb1
     startImsi: {{ imsi }}
-    ueCount: 1
+    ueCount: {{ ue_count }}
     defaultAs: {{ icmp_packet_destination }}
     opc: {{ usim_opc }}
     key: {{ usim_key }}
@@ -68,13 +68,13 @@ configuration:
       mnc: {{ mnc }}
     sequenceNumber: {{ usim_sequence_number }}
     startImsi: {{ imsi }}
-    ueCount: 1
+    ueCount: {{ ue_count }}
   - profileType: anrelease
     profileName: profile3
     enable: true
     gnbName: gnb1
     startImsi: {{ imsi }}
-    ueCount: 1
+    ueCount: {{ ue_count }}
     defaultAs: {{ icmp_packet_destination }}
     opc: {{ usim_opc }}
     key: {{ usim_key }}
@@ -92,7 +92,7 @@ configuration:
     enable: true
     gnbName: gnb1
     startImsi: {{ imsi }}
-    ueCount: 1
+    ueCount: {{ ue_count }}
     defaultAs: {{ icmp_packet_destination }}
     opc: {{ usim_opc }}
     key: {{ usim_key }}
@@ -111,7 +111,7 @@ configuration:
     enable: true
     gnbName: gnb1
     startImsi: {{ imsi }}
-    ueCount: 1
+    ueCount: {{ ue_count }}
     defaultAs: {{ icmp_packet_destination }}
     opc: {{ usim_opc }}
     key: {{ usim_key }}


### PR DESCRIPTION
# Description

Gnbsim allows for running simulations for multiple subscribers through the `ueCount` configuration option in each profile. Here we add the ability to configure the subscriber count through a Juju configuration option. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library