### PR TITLE
chore: add validation for gNB name in relation

### DIFF
--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -254,6 +254,42 @@ class TestCharmCollectUnitStatus(GNBSUMUnitTestFixtures):
                 "Invalid configuration: SD is missing from PLMN"
             )
 
+    def test_given_no_gnb_name_in_fiveg_core_gnb_plmns_when_collect_unit_status_then_status_is_blocked(  # noqa: E501
+        self,
+    ):
+        self.mock_k8s_multus.multus_is_available.return_value = True
+        self.mock_k8s_multus.is_ready.return_value = True
+        self.mock_n2_requirer_amf_hostname.return_value = "amf"
+        self.mock_n2_requirer_amf_port.return_value = 1234
+        self.mock_gnb_core_remote_tac.return_value = 2
+        plmns = [PLMNConfig(mcc="001", mnc="01", sst=1, sd=3)]
+        self.mock_gnb_core_remote_plmns.return_value = plmns
+        n2_relation = testing.Relation(endpoint="fiveg-n2", interface="fiveg_n2")
+        core_gnb_relation = testing.Relation(
+            endpoint="fiveg_core_gnb",
+            interface="fiveg_core_gnb",
+            # local_app_data={"gnb-name": "gnbsim"},
+        )
+        container = testing.Container(
+            name="gnbsim",
+            can_connect=True,
+            mounts={
+                "config": testing.Mount(
+                    location="/etc/gnbsim",
+                    source=tempfile.mkdtemp(),
+                )
+            },
+        )
+        state_in = testing.State(
+            leader=True, relations=[n2_relation, core_gnb_relation], containers=[container]
+        )
+
+        state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
+
+        assert state_out.unit_status == BlockedStatus(
+                "Invalid configuration: gNB name needs to match the following regular expression: ^[a-zA-Z][a-zA-Z0-9-_]{1,255}$"  # noqa E501
+            )
+
     def test_pre_requisites_met_when_collect_unit_status_then_status_is_active(self):
         self.mock_k8s_multus.multus_is_available.return_value = True
         self.mock_k8s_multus.is_ready.return_value = True
@@ -264,8 +300,10 @@ class TestCharmCollectUnitStatus(GNBSUMUnitTestFixtures):
         self.mock_gnb_core_remote_plmns.return_value = plmns
         n2_relation = testing.Relation(endpoint="fiveg-n2", interface="fiveg_n2")
         core_gnb_relation = testing.Relation(
-                endpoint="fiveg_core_gnb", interface="fiveg_core_gnb"
-            )
+            endpoint="fiveg_core_gnb",
+            interface="fiveg_core_gnb",
+            local_app_data={"gnb-name": "gnbsim"},
+        )
         container = testing.Container(
             name="gnbsim",
             can_connect=True,

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -23,7 +23,9 @@ class TestCharmConfigure(GNBSUMUnitTestFixtures):
             plmns = [PLMNConfig(mcc="001", mnc="01", sst=1, sd=1056816)]
             self.mock_gnb_core_remote_plmns.return_value = plmns
             core_gnb_relation = testing.Relation(
-                endpoint="fiveg_core_gnb", interface="fiveg_core_gnb"
+                endpoint="fiveg_core_gnb",
+                interface="fiveg_core_gnb",
+                local_app_data={"gnb-name": "gnbsim"},
             )
             n2_relation = testing.Relation(endpoint="fiveg-n2", interface="fiveg_n2")
             container = testing.Container(


### PR DESCRIPTION
# Description

This PR adds the validation for the gNB name in the `fiveg_core_gnb` relation. If the gNB name is not published in the relation databag, the charm goes into `Blocked` status. The message explains that the name shall match a specific regular expression.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library