### PR TITLE
chore: remove Sequence Number from charm configuration

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -90,10 +90,6 @@ config:
       type: string
       default: "981d464c7c52eb6e5036234984ad0bcf"
       description: USIM Operator Key
-    usim-sequence-number:
-      type: string
-      default: "16f3b3f70fc2"
-      description: USIM sequence number
     upf-subnet:
       type: string
       default: "192.168.252.0/24"

--- a/src/charm.py
+++ b/src/charm.py
@@ -164,8 +164,6 @@ class GNBSIMOperatorCharm(CharmBase):
             return
         if not (imsi := self._get_imsi_from_config()):
             return
-        if not (usim_sequence_number := self._get_usim_sequence_number_from_config()):
-            return
         if not (usim_opc := self._get_usim_opc_from_config()):
             return
         if not (usim_key := self._get_usim_key_from_config()):
@@ -188,7 +186,6 @@ class GNBSIMOperatorCharm(CharmBase):
             gnb_ip_address=gnb_ip_address.split("/")[0],
             icmp_packet_destination=icmp_packet_destination,
             imsi=imsi,
-            usim_sequence_number=usim_sequence_number,
             plmn=plmns[0],
             tac=tac,
             usim_opc=usim_opc,
@@ -322,9 +319,6 @@ class GNBSIMOperatorCharm(CharmBase):
     def _get_usim_opc_from_config(self) -> Optional[str]:
         return cast(Optional[str], self.model.config.get("usim-opc"))
 
-    def _get_usim_sequence_number_from_config(self) -> Optional[str]:
-        return cast(Optional[str], self.model.config.get("usim-sequence-number"))
-
     def _get_dnn_from_config(self) -> Optional[str]:
         return cast(Optional[str], self.model.config.get("dnn"))
 
@@ -368,7 +362,6 @@ class GNBSIMOperatorCharm(CharmBase):
         tac: int,
         usim_key: str,
         usim_opc: str,
-        usim_sequence_number: str,
         dnn: str,
         ue_count: int,
     ) -> str:
@@ -384,7 +377,6 @@ class GNBSIMOperatorCharm(CharmBase):
             tac: Tracking Area Code
             usim_key: USIM key
             usim_opc: USIM OPC
-            usim_sequence_number: USIM sequence number
             dnn: Data Network Name
             ue_count: Number of subscribers
 
@@ -406,7 +398,6 @@ class GNBSIMOperatorCharm(CharmBase):
             tac=format(tac, '06X'),
             usim_key=usim_key,
             usim_opc=usim_opc,
-            usim_sequence_number=usim_sequence_number,
             dnn=dnn,
             ue_count=ue_count,
         )
@@ -428,8 +419,6 @@ class GNBSIMOperatorCharm(CharmBase):
             invalid_configs.append("usim-key")
         if not self._get_usim_opc_from_config():
             invalid_configs.append("usim-opc")
-        if not self._get_usim_sequence_number_from_config():
-            invalid_configs.append("usim-sequence-number")
         return invalid_configs
 
     def _create_upf_route(self) -> None:

--- a/src/templates/config.yaml.j2
+++ b/src/templates/config.yaml.j2
@@ -40,7 +40,7 @@ configuration:
     defaultAs: {{ icmp_packet_destination }}
     opc: {{ usim_opc }}
     key: {{ usim_key }}
-    sequenceNumber: {{ usim_sequence_number }}
+    sequenceNumber: 16f3b3f70fc2
     dnn: {{ dnn }}
     sNssai:
       sst: {{ sst }}
@@ -66,7 +66,7 @@ configuration:
     plmnId:
       mcc: {{ mcc }}
       mnc: {{ mnc }}
-    sequenceNumber: {{ usim_sequence_number }}
+    sequenceNumber: 16f3b3f70fc2
     startImsi: {{ imsi }}
     ueCount: {{ ue_count }}
   - profileType: anrelease
@@ -78,7 +78,7 @@ configuration:
     defaultAs: {{ icmp_packet_destination }}
     opc: {{ usim_opc }}
     key: {{ usim_key }}
-    sequenceNumber: {{ usim_sequence_number }}
+    sequenceNumber: 16f3b3f70fc2
     dnn: {{ dnn }}
     sNssai:
       sst: {{ sst }}
@@ -96,7 +96,7 @@ configuration:
     defaultAs: {{ icmp_packet_destination }}
     opc: {{ usim_opc }}
     key: {{ usim_key }}
-    sequenceNumber: {{ usim_sequence_number }}
+    sequenceNumber: 16f3b3f70fc2
     dnn: {{ dnn }}
     retransMsg: false
     sNssai:
@@ -115,7 +115,7 @@ configuration:
     defaultAs: {{ icmp_packet_destination }}
     opc: {{ usim_opc }}
     key: {{ usim_key }}
-    sequenceNumber: {{ usim_sequence_number }}
+    sequenceNumber: 16f3b3f70fc2
     dnn: {{ dnn }}
     sNssai:
       sst: {{ sst }}

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -20,7 +20,6 @@ class TestCharmCollectUnitStatus(GNBSUMUnitTestFixtures):
             ("icmp-packet-destination"),
             ("imsi"),
             ("usim-key"),
-            ("usim-sequence-number"),
             ("upf-subnet"),
             ("upf-gateway"),
         ],


### PR DESCRIPTION
# Description

This PR removes the `usim-sequence-number` parameter from the charm configuration, since its value does not affect the simulation.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library