### PR TITLE
fix: set grafana agent channel to 1/stable in integration tests

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -21,7 +21,7 @@ FIVEG_N2_MOCK_PATH = "./tests/integration/fiveg_n2_mock_charm.py"
 AMF_MOCK = "amf-mock"
 NMS_MOCK = "nms-mock"
 GRAFANA_AGENT_CHARM_NAME = "grafana-agent-k8s"
-GRAFANA_AGENT_CHARM_CHANNEL = "latest/stable"
+GRAFANA_AGENT_CHARM_CHANNEL = "1/stable"
 TIMEOUT = 5 * 60
 
 


### PR DESCRIPTION
# Description

Grafana agent charm has been released to 1/stable. This PR updates it in the integration tests

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library